### PR TITLE
#36479224 Выводить в тултипе полное название задачи

### DIFF
--- a/src/app/modules/project-managment/start/components/space/space.component.html
+++ b/src/app/modules/project-managment/start/components/space/space.component.html
@@ -92,7 +92,12 @@
                 <div class="d-flex justify-content-between">
                   <div class="col-lg-2 laconic-text">{{t.taskTypeName}}</div>
                   <div class="col-lg-2">{{t.fullProjectTaskId}}</div>
-                  <div class="col-lg-2 laconic-text">{{t.name}}</div>
+                  <div
+                    class="col-lg-2 laconic-text"
+                    [pTooltip]="t.nameTooltip"
+                    [tooltipDisabled]="!t.nameTooltip || t.nameTooltip === t.name"
+                    tooltipPosition="bottom"
+                  >{{t.name}}</div>
                   <div class="col-lg-2 laconic-text">{{t.priorityName}}</div>
                   <div class="col-lg-2 laconic-text scrum-info-line">
                     <div>


### PR DESCRIPTION
Сделал показ тултипа если поле nameTooltip не совпадает с полем name
![image](https://github.com/user-attachments/assets/f3b87e56-8ec2-44cd-a806-da466ce263b1)
