### PR TITLE
#39659948 Левое меню накладывается на даты календаря (невозможно выбрать пункт левого меню)

### DIFF
--- a/src/app/modules/backoffice/left-menu/components/left-menu.component.scss
+++ b/src/app/modules/backoffice/left-menu/components/left-menu.component.scss
@@ -6,6 +6,7 @@
 
 .profile-left-menu {
   width: 240px;
+  z-index: 1000;
 }
 
 :host ::ng-deep .profile-left-menu .p-panelmenu {


### PR DESCRIPTION
![img](https://i.ibb.co/ZKgsgm6/Screenshot-2024-10-14-134437.jpg)

   - [x] Добавил z-index классу .profile-left-menu

Согласно [документации](https://primeng.org/tieredmenu) это решается добавлением атрибутов самому TieredMenu, но тут или всем элементам нужно выставлять или из-за вложенности не работает.
```html
<p-tieredMenu [baseZIndex]="1000" [autoZIndex]="true" [model]="profileItems$.value.items" />
```
  
Еще есть два варианта:
 - это или инлайновые стили для самого компонента 
 - добавить еще один класс. 

Посчитал что такое решения самое простое и менее запутанное.
 
